### PR TITLE
fix: completions error on zsh

### DIFF
--- a/src/_claude
+++ b/src/_claude
@@ -282,7 +282,3 @@ _claude_mcp() {
     esac
   fi
 }
-
-
-# Main completion function
-_claude "$@"


### PR DESCRIPTION
_arguments:comparguments:327: can only be called from completion function

fixes this error that i was getting
